### PR TITLE
Implement useVoiceClientMediaTrack

### DIFF
--- a/rtvi-client-react/src/VoiceClientAudio.tsx
+++ b/rtvi-client-react/src/VoiceClientAudio.tsx
@@ -1,23 +1,20 @@
-import { useCallback, useRef } from "react";
-import { useVoiceClientEvent } from "./useVoiceClientEvent";
-import { VoiceEvent } from "realtime-ai";
+import { useEffect, useRef } from "react";
+import { useVoiceClientMediaTrack } from "./useVoiceClientMediaTrack";
 
 export const VoiceClientAudio = () => {
   const botAudioRef = useRef<HTMLAudioElement>(null);
+  const botAudioTrack = useVoiceClientMediaTrack("audio", "bot");
 
-  useVoiceClientEvent(
-    VoiceEvent.TrackStarted,
-    useCallback((track, p) => {
-      if (p?.local || !botAudioRef.current) return;
-      if (botAudioRef.current.srcObject) {
-        const oldTrack = (
-          botAudioRef.current.srcObject as MediaStream
-        ).getAudioTracks()[0];
-        if (oldTrack.id === track.id) return;
-      }
-      botAudioRef.current.srcObject = new MediaStream([track]);
-    }, [])
-  );
+  useEffect(() => {
+    if (!botAudioRef.current || !botAudioTrack) return;
+    if (botAudioRef.current.srcObject) {
+      const oldTrack = (
+        botAudioRef.current.srcObject as MediaStream
+      ).getAudioTracks()[0];
+      if (oldTrack.id === botAudioTrack.id) return;
+    }
+    botAudioRef.current.srcObject = new MediaStream([botAudioTrack]);
+  }, [botAudioTrack]);
 
   return (
     <>

--- a/rtvi-client-react/src/index.ts
+++ b/rtvi-client-react/src/index.ts
@@ -3,4 +3,5 @@ export { VoiceClientProvider } from "./VoiceClientProvider";
 export { useVoiceClient } from "./useVoiceClient";
 export { useVoiceClientEvent } from "./useVoiceClientEvent";
 export { useVoiceClientMediaDevices } from "./useVoiceClientMediaDevices";
+export { useVoiceClientMediaTrack } from "./useVoiceClientMediaTrack";
 export { useVoiceClientTransportState } from "./useVoiceClientTransportState";

--- a/rtvi-client-react/src/useVoiceClientMediaTrack.ts
+++ b/rtvi-client-react/src/useVoiceClientMediaTrack.ts
@@ -1,0 +1,28 @@
+import { Tracks, VoiceEvent } from "realtime-ai";
+import { useVoiceClientEvent } from "./useVoiceClientEvent";
+import { useCallback, useState } from "react";
+
+type ParticipantType = keyof Tracks;
+type TrackType = keyof Tracks["local"];
+
+export const useVoiceClientMediaTrack = (
+  trackType: TrackType,
+  participantType: ParticipantType
+) => {
+  const [track, setTrack] = useState<MediaStreamTrack | null>(null);
+  const isLocal = participantType === "local";
+
+  useVoiceClientEvent(
+    VoiceEvent.TrackStarted,
+    useCallback(
+      (t, p) => {
+        if (isLocal !== p?.local || t.kind !== trackType || t.id === track?.id)
+          return;
+        setTrack(t);
+      },
+      [participantType, track, trackType]
+    )
+  );
+
+  return track;
+};

--- a/rtvi-client-react/src/useVoiceClientMediaTrack.ts
+++ b/rtvi-client-react/src/useVoiceClientMediaTrack.ts
@@ -1,26 +1,53 @@
 import { Tracks, VoiceEvent } from "realtime-ai";
 import { useVoiceClientEvent } from "./useVoiceClientEvent";
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
+import { atom, useAtomValue } from "jotai";
+import { atomFamily, useAtomCallback } from "jotai/utils";
+import { Atom } from "jotai/vanilla";
 
 type ParticipantType = keyof Tracks;
 type TrackType = keyof Tracks["local"];
+
+const localAudioTrackAtom = atom<MediaStreamTrack | null>(null);
+const localVideoTrackAtom = atom<MediaStreamTrack | null>(null);
+const botAudioTrackAtom = atom<MediaStreamTrack | null>(null);
+const botVideoTrackAtom = atom<MediaStreamTrack | null>(null);
+
+const trackAtom = atomFamily<
+  { local: boolean; trackType: TrackType },
+  Atom<MediaStreamTrack | null>
+>(({ local, trackType }) => {
+  if (local)
+    return trackType === "audio" ? localAudioTrackAtom : localVideoTrackAtom;
+  return trackType === "audio" ? botAudioTrackAtom : botVideoTrackAtom;
+});
 
 export const useVoiceClientMediaTrack = (
   trackType: TrackType,
   participantType: ParticipantType
 ) => {
-  const [track, setTrack] = useState<MediaStreamTrack | null>(null);
-  const isLocal = participantType === "local";
+  const track = useAtomValue(
+    trackAtom({ local: participantType === "local", trackType })
+  );
 
   useVoiceClientEvent(
     VoiceEvent.TrackStarted,
-    useCallback(
-      (t, p) => {
-        if (isLocal !== p?.local || t.kind !== trackType || t.id === track?.id)
-          return;
-        setTrack(t);
-      },
-      [participantType, track, trackType]
+    useAtomCallback(
+      useCallback(
+        (get, set, t, p) => {
+          const atom = p?.local
+            ? t.kind === "audio"
+              ? localAudioTrackAtom
+              : localVideoTrackAtom
+            : t.kind === "audio"
+            ? botAudioTrackAtom
+            : botVideoTrackAtom;
+          const oldTrack = get(atom);
+          if (oldTrack?.id === t.id) return;
+          set(atom, t);
+        },
+        [participantType, track, trackType]
+      )
     )
   );
 


### PR DESCRIPTION
This implements a new React hook `useVoiceClientMediaTrack()` which will help to return a stateful representation of audio & video tracks. When attaching tracks to the DOM via React, this will make sure that components attaching those tracks are informed about track updates, e.g. after switching to a different microphone or camera, or when a remote track had to be replaced due to a reconnect or media move.

Also this hook is now used inside the `VoiceClientAudio` component.