### PR TITLE
Add initDevices lifecycle method

### DIFF
--- a/rtvi-client-js/src/core.ts
+++ b/rtvi-client-js/src/core.ts
@@ -177,6 +177,10 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
   }
 
   // ------ Transport methods
+  public async initDevices() {
+    await this._transport.initDevices();
+  }
+
   public async start() {
     this._transport.state = "handshaking";
 

--- a/rtvi-client-js/src/transport/core.ts
+++ b/rtvi-client-js/src/transport/core.ts
@@ -3,6 +3,8 @@ import { VoiceEventCallbacks } from "../core";
 
 export type TransportState =
   | "idle"
+  | "initializing"
+  | "initialized"
   | "handshaking"
   | "connecting"
   | "connected"
@@ -43,6 +45,8 @@ export abstract class Transport {
     this._config = options.config ?? {};
     this._onMessage = onMessage;
   }
+
+  abstract initDevices(): Promise<void>;
 
   abstract connect({
     url,

--- a/rtvi-sandbox/src/DemoApp.tsx
+++ b/rtvi-sandbox/src/DemoApp.tsx
@@ -186,7 +186,16 @@ export const DemoApp = () => {
         </select>
       </label>
       <hr />
-      <button disabled={transportState !== "idle"} onClick={() => start()}>
+      <button
+        disabled={transportState !== "idle"}
+        onClick={() => voiceClient.initDevices()}
+      >
+        Init devices
+      </button>
+      <button
+        disabled={transportState !== "idle" && transportState !== "initialized"}
+        onClick={() => start()}
+      >
         Connect
       </button>
       <button disabled={!isConnected} onClick={() => voiceClient.disconnect()}>


### PR DESCRIPTION
This adds a new `initDevices()` lifecycle method, which can be optionally called before `start()` from a voice client instance.
`initDevices()` is essentially a wrapper around `startCamera()` in the Daily transport layer, which allows developers to tie the initialization of devices and audio contexts to a user gesture, as required by browsers.
This adds two new transport states: `"initializing"` and `"initialized"`.
`initDevices()` is a no-op when the transport state is not `"idle"`.