### PR TITLE
Guardclause starting audio level observers

### DIFF
--- a/rtvi-client-js/package.json
+++ b/rtvi-client-js/package.json
@@ -21,7 +21,7 @@
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0"
   },
   "devDependencies": {
-    "@daily-co/daily-js": "^0.67.0",
+    "@daily-co/daily-js": "^0.68.0",
     "@typescript-eslint/eslint-plugin": "^7.16.0",
     "@typescript-eslint/parser": "^7.16.0",
     "eslint": "9.x",
@@ -38,6 +38,6 @@
     "typed-emitter": "^2.1.0"
   },
   "peerDependencies": {
-    "@daily-co/daily-js": ">=0.67.0"
+    "@daily-co/daily-js": ">=0.68.0"
   }
 }

--- a/rtvi-client-js/src/transport/daily.ts
+++ b/rtvi-client-js/src/transport/daily.ts
@@ -157,8 +157,10 @@ export class DailyTransport extends Transport {
     this._localAudioLevelObserver = this.createAudioLevelProcessor(
       dailyParticipantToParticipant(this._daily.participants().local)
     );
-    await this._daily.startLocalAudioLevelObserver(100);
-    await this._daily.startRemoteParticipantsAudioLevelObserver(100);
+    if (!this._daily.isLocalAudioLevelObserverRunning())
+      await this._daily.startLocalAudioLevelObserver(100);
+    if (!this._daily.isRemoteParticipantsAudioLevelObserverRunning())
+      await this._daily.startRemoteParticipantsAudioLevelObserver(100);
 
     this.state = "initialized";
   }

--- a/rtvi-sandbox/package.json
+++ b/rtvi-sandbox/package.json
@@ -25,7 +25,7 @@
     "vite": "^5.3.1"
   },
   "dependencies": {
-    "@daily-co/daily-js": "^0.67.0",
+    "@daily-co/daily-js": "^0.68.0",
     "realtime-ai": "*",
     "realtime-ai-react": "*",
     "@vitejs/plugin-react": "^4.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -219,10 +219,10 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
-"@daily-co/daily-js@^0.67.0":
-  version "0.67.0"
-  resolved "https://registry.yarnpkg.com/@daily-co/daily-js/-/daily-js-0.67.0.tgz#94a3edd2c137a3fb684a91fb3ae02273de06f19f"
-  integrity sha512-aTOqM6T+T56PVVmIOSbj6He7aU8NjHiKMFe7uS944tU9TwJ7jscTfPkre/v4IKFuYYahUVh9Ko5R08KKE8hprQ==
+"@daily-co/daily-js@^0.68.0":
+  version "0.68.0"
+  resolved "https://registry.yarnpkg.com/@daily-co/daily-js/-/daily-js-0.68.0.tgz#da0d41b230fe3f03bb6eb22fc168bfd77e5222bc"
+  integrity sha512-X7TVp++SVJ78VqM4ruWpjUBWbEpOZa/hfgn/tI2ejyF+GzpUlficWKwlE4ZP1jG/c/kntMiy9XQEHijUoWdulg==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@sentry/browser" "^7.60.1"


### PR DESCRIPTION
- Updates daily-js to 0.68.0 to have access to audio level observer checker methods
- Adds guard clauses to starting audio level observers