### PR TITLE
Prevent state mutation when new state is the same

### DIFF
--- a/rtvi-client-js/src/transport/daily.ts
+++ b/rtvi-client-js/src/transport/daily.ts
@@ -55,6 +55,8 @@ export class DailyTransport extends Transport {
   }
 
   private set state(state: TransportState) {
+    if (this._state === state) return;
+
     this._state = state;
     this._callbacks.onTransportStateChanged?.(state);
   }


### PR DESCRIPTION
Some workflows may signal a ready state more than once. This check avoids a mutation of the property when the values are the same.