### PR TITLE
change message label from rtvi to  rtvi-ai

### DIFF
--- a/rtvi-client-js/src/core.ts
+++ b/rtvi-client-js/src/core.ts
@@ -295,7 +295,7 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
     {
       useDeepMerge = false,
       sendPartial = false,
-    }: { useDeepMerge?: boolean; sendPartial?: boolean }
+    }: { useDeepMerge?: boolean; sendPartial?: boolean } = {}
   ) {
     // @TODO refactor this method to use a reducer
     if (useDeepMerge) {

--- a/rtvi-client-js/src/messages.ts
+++ b/rtvi-client-js/src/messages.ts
@@ -49,7 +49,7 @@ export type Transcript = {
 
 export class VoiceMessage {
   id: string;
-  label: string = "rtvi";
+  label: string = "rtvi-ai";
   type: string;
   data: unknown;
 
@@ -86,9 +86,9 @@ export class VoiceMessage {
   // TTS
   static speak(message: string, interrupt: boolean): VoiceMessage {
     // Sent when prompting the STT model to speak
-    return new VoiceMessage(VoiceMessageType.SPEAK, {
-      tts: { text: message, interrupt },
-    });
+    return new VoiceMessage(VoiceMessageType.SPEAK,
+      { text: message, interrupt },
+    );
   }
 
   static interrupt(): VoiceMessage {

--- a/rtvi-client-js/src/transport/daily.ts
+++ b/rtvi-client-js/src/transport/daily.ts
@@ -240,13 +240,13 @@ export class DailyTransport extends Transport {
 
   private handleAppMessage(ev: DailyEventObjectAppMessage) {
     // Bubble any messages with realtime-ai label
-    if (ev.data.label === "rtvi") {
+    if (ev.data.label === "rtvi-ai") {
       this._onMessage({
         type: ev.data.type,
         data: ev.data,
       } as VoiceMessage);
     } else if (ev.data.type === "pipecat-metrics") {
-      // Bubble up pipecat metrics, which don't have the "rtvi" label
+      // Bubble up pipecat metrics, which don't have the "rtvi-ai" label
       const vmm = new VoiceMessageMetrics(ev.data.metrics as PipecatMetrics);
       this._onMessage(vmm);
     }


### PR DESCRIPTION
Label change to align with update on the Pipecat side.

There's more work to do here on the various message formats. But maybe makes sense to merge this, now.

Tested with:

```
voiceClient.say("What a beautiful day.")
```
