### PR TITLE
Fix an issue disallowing a DailyVoiceClient to be recreated.

### DIFF
--- a/rtvi-client-js-daily/src/transport.ts
+++ b/rtvi-client-js-daily/src/transport.ts
@@ -43,9 +43,14 @@ export class DailyTransport extends Transport {
   ) {
     super(options, onMessage);
 
+    const existingInstance = Daily.getCallInstance();
+    if (existingInstance) {
+      void existingInstance.destroy();
+    }
     this._daily = Daily.createCallObject({
       videoSource: options.enableCam ?? false,
       audioSource: options.enableMic ?? false,
+      allowMultipleCallInstances: true,
       dailyConfig: {},
     });
 


### PR DESCRIPTION
With this fix, you still can only have one DailyVoiceClient at a time, with the most recent one working. However, instead of throwing an error when trying to create a new one, it will disable the existing one.

This avoids issues in React when the DailyVoiceClient belongs to a compoenent that comes and goes.