### PR TITLE
version 0.1.8 bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to **RTVI Client Web** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.8] - 2024-09-02
+
+### Fixed
+
+- `getServiceOptionsFromConfig` and `getServiceOptionValueFromConfig` return a deep clone of property to avoid references in returned values.
+- LLM Helper `getContext` now returns a new instance of context when not in ready state.
+
+### Changed
+
+- `updateConfig` now calls the `onConfigUpdated` callback (and event) when not in ready state.
+
+
 ## [0.1.7] - 2024-08-28
 
 ### Fixed

--- a/rtvi-client-js-daily/package.json
+++ b/rtvi-client-js-daily/package.json
@@ -1,6 +1,6 @@
 {
     "name": "realtime-ai-daily",
-    "version": "0.1.7",
+    "version": "0.1.8",
     "license": "BSD-2-Clause",
     "main": "dist/index.js",
     "module": "dist/index.module.js",

--- a/rtvi-client-js/package.json
+++ b/rtvi-client-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realtime-ai",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",

--- a/rtvi-client-js/src/core.ts
+++ b/rtvi-client-js/src/core.ts
@@ -599,10 +599,9 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
     }
 
     // Find matching option key in the service config
-    const optionValue: ConfigOption | undefined = cloneDeep(
-      configServiceKey.options.find((o: ConfigOption) => o.name === option)
+    const optionValue: ConfigOption | undefined = configServiceKey.options.find(
+      (o: ConfigOption) => o.name === option
     );
-
     return ({ ...optionValue } as ConfigOption).value;
   }
 

--- a/rtvi-client-js/src/core.ts
+++ b/rtvi-client-js/src/core.ts
@@ -309,6 +309,7 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
         const customAuthHandler = this._options.customAuthHandler;
 
         console.debug("[RTVI Client] Connecting to baseUrl", this._baseUrl);
+        console.debug("[RTVI Client] Config", config);
 
         try {
           if (customAuthHandler) {
@@ -526,6 +527,7 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
       );
     } else {
       this._options.config = config;
+      this._options.callbacks?.onConfigUpdated?.(config);
     }
   }
 
@@ -569,7 +571,7 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
     }
 
     // Return a new object, as to not mutate existing state
-    return { ...configServiceKey };
+    return cloneDeep(configServiceKey);
   }
 
   /**
@@ -597,8 +599,8 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
     }
 
     // Find matching option key in the service config
-    const optionValue: ConfigOption | undefined = configServiceKey.options.find(
-      (o: ConfigOption) => o.name === option
+    const optionValue: ConfigOption | undefined = cloneDeep(
+      configServiceKey.options.find((o: ConfigOption) => o.name === option)
     );
 
     return ({ ...optionValue } as ConfigOption).value;

--- a/rtvi-client-js/src/helpers/llm.ts
+++ b/rtvi-client-js/src/helpers/llm.ts
@@ -92,10 +92,13 @@ export class LLMHelper extends VoiceClientHelper {
         action: "get_context",
       } as ActionData) as Promise<LLMContextMessage[]>;
     } else {
-      return this._voiceClient.getServiceOptionValueFromConfig(
-        this._service,
-        this._getMessagesKey()
-      ) as LLMContextMessage[];
+      const currentContext: LLMContextMessage[] =
+        this._voiceClient.getServiceOptionValueFromConfig(
+          this._service,
+          this._getMessagesKey()
+        ) as LLMContextMessage[];
+
+      return [...currentContext];
     }
   }
 

--- a/rtvi-client-js/tests/config.spec.ts
+++ b/rtvi-client-js/tests/config.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "@jest/globals";
 
 import {
   ConfigOption,
+  LLMContextMessage,
   VoiceClient,
   type VoiceClientConfigOption,
   VoiceClientServices,
@@ -105,6 +106,48 @@ describe("Voice Client Config Getter Helper Methods", () => {
     expect(
       voiceClient.getServiceOptionValueFromConfig("llm", "test")
     ).toBeUndefined();
+  });
+
+  test("getServiceOptionsFromConfig should return a new instance of service config", () => {
+    let value: VoiceClientConfigOption =
+      voiceClient.getServiceOptionsFromConfig("llm") as VoiceClientConfigOption;
+
+    const messages = value.options[1].value as LLMContextMessage[];
+    messages[0].content = "test";
+
+    expect(
+      voiceClient.getServiceOptionValueFromConfig("llm", "initial_messages")
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          role: "system",
+          content:
+            "You are a assistant called ExampleBot. You can ask me anything.",
+        },
+      ])
+    );
+  });
+
+  test("getServiceOptionFromConfig should return a new instance of config option", () => {
+    let value: LLMContextMessage[] =
+      voiceClient.getServiceOptionValueFromConfig(
+        "llm",
+        "initial_messages"
+      ) as LLMContextMessage[];
+
+    value[0].content = "test";
+
+    expect(
+      voiceClient.getServiceOptionValueFromConfig("llm", "initial_messages")
+    ).toEqual(
+      expect.arrayContaining([
+        {
+          role: "system",
+          content:
+            "You are a assistant called ExampleBot. You can ask me anything.",
+        },
+      ])
+    );
   });
 });
 

--- a/rtvi-client-js/tests/config.spec.ts
+++ b/rtvi-client-js/tests/config.spec.ts
@@ -5,6 +5,7 @@ import {
   VoiceClient,
   type VoiceClientConfigOption,
   VoiceClientServices,
+  VoiceEvent,
 } from "../src/";
 import { TransportStub } from "./transport.stub";
 
@@ -258,12 +259,43 @@ describe("updateConfig method", () => {
   });
 
   test("updateConfig method should update the config", () => {
-    const newConfig = voiceClient.setServiceOptionInConfig("test", {
+    const newConfig = voiceClient.setServiceOptionInConfig("tts", {
       name: "test",
       value: "test",
     } as ConfigOption);
 
     voiceClient.updateConfig(newConfig);
-    expect(voiceClient.config).toEqual(newConfig);
+
+    expect(newConfig).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          service: "tts",
+          options: expect.arrayContaining([{ name: "test", value: "test" }]),
+        }),
+      ])
+    );
+  });
+
+  test("updateConfig should trigger onConfigUpdate event", async () => {
+    const newConfig = voiceClient.setServiceOptionInConfig("tts", {
+      name: "test",
+      value: "test2",
+    } as ConfigOption);
+
+    const handleConfigUpdate = (updatedConfig: VoiceClientConfigOption[]) => {
+      expect(updatedConfig).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            service: "tts",
+            options: expect.arrayContaining([{ name: "test", value: "test2" }]),
+          }),
+        ])
+      );
+    };
+    voiceClient.on(VoiceEvent.ConfigUpdated, handleConfigUpdate);
+
+    await voiceClient.updateConfig(newConfig);
+
+    voiceClient.off(VoiceEvent.ConfigUpdated, handleConfigUpdate);
   });
 });

--- a/rtvi-client-react/package.json
+++ b/rtvi-client-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "realtime-ai-react",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "license": "BSD-2-Clause",
   "main": "dist/index.js",
   "module": "dist/index.module.js",


### PR DESCRIPTION
## [0.1.8] - 2024-09-02

### Fixed

- `getServiceOptionsFromConfig` and `getServiceOptionValueFromConfig` return a deep clone of property to avoid references in returned values.
- LLM Helper `getContext` now returns a new instance of context when not in ready state.

### Changed

- `updateConfig` now calls the `onConfigUpdated` callback (and event) when not in ready state.

